### PR TITLE
NINEDOCS-142 JVM 메모리 옵션 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -jar app.jar \
+ENV JVM_OPTIONS="-Xms128m -Xmx384m"
+
+ENTRYPOINT ["sh", "-c", "java \
+  ${JVM_OPTIONS} \
+  -jar app.jar \
   --spring.profiles.active=${PROFILE} \
   -DRDS_URL=${RDS_URL} \
   -DRDS_USERNAME=${RDS_USERNAME} \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# 이미지 빌드 및 실행
+프로젝트 root 위치에서 명령 실행
+```bash
+# 이미지 빌드
+docker build -t (이미지이름) .
+
+# 컨테이너 실행
+docker run --name (원하는 컨테이너 이름) -d -p 80:8080 --env-file (.env 파일 위치) (이미지이름)
+```
+
 # Redis, Mysql 로컬 환경 전용 docker-compose
 
 ## Redis


### PR DESCRIPTION
- Xms
  - 옵션 설명
    - 프로그램 실행 시 부여할 초기 JVM heap 메모리 크기 지정
    - 참고 : JVM은 실행 도중 heap 메모리가 추가로 필요해지면 추가로 할당함. 이후 다시 heap 메모리 크기를 줄이지는 않음
  - 설정 이유
    - 이 값을 너무 낮게 설정하면, JVM이 필요한 메모리를 요청할 때마다 추가적으로 메모리를 할당해야 하므로 성능에 영향을 미침
    - 이 값을 너무 크게 설정하면, 초기에 메모리를 과도하게 점유하여 낭비를 초래함.
      - 특히 컨테이너 환경에서는 가용 메모리를 효율적으로 사용해야 하므로, 필요 이상의 초기 메모리 할당은 비효율적일 수 있다.
    - 기본값 : 이 값을 설정하지 않을 경우 기본값은 가용 메모리의 작은 비율(보통 1/64)로 설정됨 
      - AWS t3.medium AMI 기준으로 봤을 때 64MiB 이하로 매우 작게 할당될 것으로 예상됨
  - 설정 기준
    - Xms는 컨테이너에 요청된 메모리(memory.requests)보다 작게 설정
      - K8s deployment manifest의 컨테이너 `memory.requests = 300Mi` 을 기준으로하여, default 값을 128Mi로 부여했음
- Xmx
  - 옵션 설명
    - JVM이 사용할 수 있는 최대 힙 메모리 크기 지정
    - 애플리케이션이 Xmx 값을 넘어선 크기의 heap 메모리를 사용하려고 하면 
OutOfMemoryError가 발생
    - 너무 큰 값은 낭비를 유발하고, 너무 작은 값은 GC가 자주 발생해 성능 저하를 초래
  - 설정 이유
    - 애플리케이션이 의도치 않게 너무 많은 메모리를 사용하여 시스템 전체를 불안정하게 만드는 것을 방지 (예: 시스템에서 다른 애플리케이션과 자원을 공유하는 환경)
    - 이 값을 너무 크게 설정하면, 이 메모리를 다른 애플리케이션이나 시스템에서 사용할 수 없기 때문에 불필요한 메모리 점유로 이어질 수 있음.
      또한 힙 크기가 크면 GC가 실행될 때 처리 시간이 길어져 애플리케이션 응답 시간이 증가할 수 있음
    - 이 값이 너무 작으면 메모리가 부족해 OutOfMemoryError가 발생할 가능성이 높아집니다.
GC가 너무 자주 발생(GC thrashing)하며, 애플리케이션 성능이 급격히 저하됨 