### PR TITLE
NINEDOCS-157 토큰 만료기간 이상한 문제 해결

### DIFF
--- a/src/main/java/com/ninedocs/userserver/UserServerApplication.java
+++ b/src/main/java/com/ninedocs/userserver/UserServerApplication.java
@@ -1,5 +1,7 @@
 package com.ninedocs.userserver;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -9,5 +11,10 @@ public class UserServerApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(UserServerApplication.class, args);
+  }
+
+  @PostConstruct
+  public void init() {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
   }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,6 +1,5 @@
 jwt:
   secret: secret-64-byte-minimum-secret-key-which-must-be-long-enough-for-hmac
-  access-token-expiration-ms: 3600000
 logging:
   level:
     com.ninedocs.userserver: DEBUG

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -13,7 +13,6 @@ spring:
       password: ${REDIS_PASSWORD}
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration-ms: 3600000
 logging:
   level:
     root: WARN

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,5 @@ spring:
     redis:
       host: localhost
       port: 6379
+jwt:
+  access-token-expiration-ms: 21600000    # 6시간


### PR DESCRIPTION
## 문제
- AWS 배포 시 토큰 만료 일시가 현재시간보다 몇시간 전으로 나옴
![image](https://github.com/user-attachments/assets/a29d408d-bccd-4b39-bed7-9a58238d5e89)



## 원인 분석
- AWS에서 실행시 서버의 timezone 이 달라지는 것으로 보임
- 토큰 유효기간이 6분(3600000ms)으로 설정되어있음
