### PR TITLE
refactor: commit hash 앞에 V- 를 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
             steps {
                 script {
                     // Set TAG to the short commit hash
-                    env.TAG = sh(script: "git rev-parse --short HEAD", returnStdout: true).trim()
+                    env.TAG = "V-" + sh(script: "git rev-parse --short HEAD", returnStdout: true).trim()
                     echo "Git Commit Hash: ${env.TAG}"
                 }
             }


### PR DESCRIPTION
- git hash가 가끔 전부 숫자로 이루어질 때 argo cd에서 에러 발생
- 이미지 태그를 V- + git commit hash로 변경