### PR TITLE
NINEDOCS-192 Dockerfile base image 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN ./gradlew clean build -x test
 
 # Run stage
 
-FROM kiel0103/ninedocs-jdk-base:v1
+FROM amazoncorretto:17
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN ./gradlew clean build -x test
 
 # Run stage
 
-FROM amazoncorretto:17.0.13-alpine3.20
+FROM kiel0103/ninedocs-jdk-base:v1
 
 WORKDIR /app
 


### PR DESCRIPTION
## 문제 상황
기존에 base image로 `amazoncorretto:17.0.13-alpine3.20`를 사용하고 있었다.
그런데 amazoncorretto 에서 이 태그에 해당하는 이미지를 없애버린 듯. (지금 찾아보면 없음)

여태까지는 Jenkins 에 캐시되어있던걸 사용하고 있었어서 문제 없었는데,
이후 Jenkins 에서 docker 캐시가 날아가면서
원격에 이미지가 없어진게 반영되어 빌드에 실패함


## 해결
- 이미지 교체